### PR TITLE
Remove obsolete localization entry

### DIFF
--- a/DBM-HeartofFear/localization.cn.lua
+++ b/DBM-HeartofFear/localization.cn.lua
@@ -50,7 +50,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "特殊警报：当你在首领身体下方时",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).."（仅英雄难度）"
 })
 
 L:SetMiscLocalization({

--- a/DBM-HeartofFear/localization.de.lua
+++ b/DBM-HeartofFear/localization.de.lua
@@ -44,7 +44,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "Spezialwarnung, wenn du dich unter dem Boss befindest",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).."<br/>(nur heroischer Schwierigkeitsgrad)"
 })
 
 L:SetMiscLocalization({

--- a/DBM-HeartofFear/localization.en.lua
+++ b/DBM-HeartofFear/localization.en.lua
@@ -49,7 +49,6 @@ L:SetWarningLocalization({
 L:SetOptionLocalization({
 	warnCrush		= DBM_CORE_AUTO_ANNOUNCE_OPTIONS.spell:format(122774),
 	specwarnUnder	= "Show special warning when you are under boss",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).." (Heroic difficulty only)",
 	PheromonesIcon	= DBM_CORE_AUTO_ICONS_OPTION_TEXT:format(122835)
 })
 

--- a/DBM-HeartofFear/localization.es.lua
+++ b/DBM-HeartofFear/localization.es.lua
@@ -52,7 +52,6 @@ L:SetWarningLocalization({
 L:SetOptionLocalization({
 	warnCrush		= DBM_CORE_AUTO_ANNOUNCE_OPTIONS.spell:format(122774),
 	specwarnUnder	= "Mostrar aviso especial cuando estés debajo del jefe",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).." (dificultad heroica)",
 	PheromonesIcon	= DBM_CORE_AUTO_ICONS_OPTION_TEXT:format(122835)
 })
 

--- a/DBM-HeartofFear/localization.fr.lua
+++ b/DBM-HeartofFear/localization.fr.lua
@@ -52,7 +52,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "Alerte spécial quand vous êtes sous le Boss",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).." (Difficulté héroïque seulement)"
 })
 
 L:SetMiscLocalization({

--- a/DBM-HeartofFear/localization.kr.lua
+++ b/DBM-HeartofFear/localization.kr.lua
@@ -44,7 +44,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "가랄론의 보라색 원 안에 있을때 특수 경고 보기",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).."(영웅 난이도만)"
 })
 
 L:SetMiscLocalization({

--- a/DBM-HeartofFear/localization.ru.lua
+++ b/DBM-HeartofFear/localization.ru.lua
@@ -45,7 +45,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "Спец-предупреждение, когда вы стоите под боссом",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).." (только в героическом режиме)"
 })
 
 L:SetMiscLocalization({

--- a/DBM-HeartofFear/localization.tw.lua
+++ b/DBM-HeartofFear/localization.tw.lua
@@ -43,7 +43,6 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	specwarnUnder	= "當你在紫色圓圈範圍內顯示特別警告",
-	countdownCrush	= DBM_CORE_AUTO_COUNTDOWN_OPTION_TEXT:format(122774).." (只有英雄模式)"
 })
 
 L:SetMiscLocalization({


### PR DESCRIPTION
This entry was left unused after https://github.com/DeadlyBossMods/DBM-MoP/commit/11791be03ea5719d4a975efee149efc687bb8f08 and started throwing an error after https://github.com/DeadlyBossMods/DeadlyBossMods/commit/96875925b14b87a735e87472ef24b9e7aa1a2fe8.

Failure to fully load localization files causes further errors in Garalon and Shek'zeer mods:
`bad argument #1 to 'find' (string expected, got nil)`.